### PR TITLE
ci: harden release verification secret access

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -13,6 +13,9 @@ on:
   pull_request:
     branches: [ "main" ]
   workflow_call:
+    secrets:
+      CODECOV_TOKEN:
+        required: false
 
 permissions:
   contents: read

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,8 @@ concurrency:
 jobs:
   verify:
     uses: ./.github/workflows/gradle.yml
-    secrets: inherit
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   publish:
     name: Release build, publish, and create GitHub release


### PR DESCRIPTION
### Motivation
- Reduce CI/CD attack surface by preventing the reusable verification job from inheriting publishing/signing secrets so a mutable workflow cannot exfiltrate or abuse sensitive credentials.
- Complement the earlier switch to `release`-event publishing by applying least-privilege to the verification step that runs before the publish job.

### Description
- Add an explicit optional `CODECOV_TOKEN` `workflow_call` secret to `.github/workflows/gradle.yml` so callers can pass only that token when invoking the reusable workflow. 
- Replace `secrets: inherit` with an explicit `CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}` mapping for the `verify` job in `.github/workflows/publish.yml` so Maven Central, signing, and other publish secrets are no longer passed to verification. 
- Preserve least-privilege permissions by keeping top-level `contents: read` and limiting `contents: write` to the `publish` job only.

### Testing
- Validated both workflow YAML files with a YAML parser which succeeded. 
- Ran `git diff --check` and `git diff --cached --check` to ensure no whitespace/format issues, both checks passed. 
- `actionlint` was not installed in the environment, so full workflow linting was not executed in this run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6cb9b99b8c8329b02de4c695b0d9b0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated verification workflows to support an optional code coverage token.
  * Limited secret forwarding during publishing checks to the required coverage token.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->